### PR TITLE
T1127.001 MSBuild

### DIFF
--- a/datasets/attack_techniques/T1127.001/atomic_red_team.yml
+++ b/datasets/attack_techniques/T1127.001/atomic_red_team.yml
@@ -1,0 +1,14 @@
+author: Michael Haag
+date: '2021-01-15'
+description: MSBuild.exe execution simulating renamed, moved and performing a network connection. 
+environment: attack_range
+technique:
+- T1127.001
+dataset:
+- https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1127.001/atomic_red_team/windows-sysmon.log
+references:
+- https://attack.mitre.org/techniques/T1127/001/
+- https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1127.001/T1127.001.md
+- https://lolbas-project.github.io/lolbas/Binaries/Msbuild/
+sourcetypes:
+- XmlWinEventLog:Microsoft-Windows-Sysmon/Operational

--- a/datasets/attack_techniques/T1127.001/windows-sysmon.log
+++ b/datasets/attack_techniques/T1127.001/windows-sysmon.log
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bcfea257d20d9375c5f80b4ec291e2d71b4bc6c520fddfe932428613c184c820
+size 27992329


### PR DESCRIPTION
Adding T1127.001 MSBuild attack data. Emulating msbuild with a network connection, suspicious spawn from wmiprvse, renamed and non-standard path.