### PR TITLE
Exchange 2016 IIS Logs

### DIFF
--- a/datasets/suspicious_behaviour/exchange_2016_iis/exchange_2016_iis.log
+++ b/datasets/suspicious_behaviour/exchange_2016_iis/exchange_2016_iis.log
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:21ae225c70ab7996223fd54c9b4cbde2dcaa38a6257333ab58d1bd02053bd71e
+size 16678315

--- a/datasets/suspicious_behaviour/exchange_2016_iis/exchange_2016_iis.yml
+++ b/datasets/suspicious_behaviour/exchange_2016_iis/exchange_2016_iis.yml
@@ -1,0 +1,14 @@
+author: Michael Haag
+date: '2021-03-11'
+description: This dataset includes Microsoft Exchange 2016 IIS logs, related to vulnerabilities exploited by HAFNIUM Group. The vulnerabilities recently being exploited were CVE-2021-26855, CVE-2021-26857, CVE-2021-26858, and CVE-2021-27065.
+environment: attack_range
+technique:
+- T1505.003
+dataset:
+- https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/suspicious_behaviour/exchange_2016_iis/exchange_2016_iis.log
+references:
+- https://www.splunk.com/en_us/blog/security/detecting-hafnium-exchange-server-zero-day-activity-in-splunk.html
+- https://my.netsurion.com/hafnium-detection-and-monitoring-solution
+- https://www.microsoft.com/security/blog/2021/03/02/hafnium-targeting-exchange-servers/
+sourcetypes:
+- MSWindows:2012:IIS


### PR DESCRIPTION
Microsoft Exchange 2016 IIS logs related to vulnerabilities recently being exploited - CVE-2021-26855, CVE-2021-26857, CVE-2021-26858, and CVE-2021-27065. No successful exploitation occurred, however lots of scanners looking for exploited servers.