### PR TITLE
adding attack_data for CVE-2021-1675

### DIFF
--- a/datasets/T1547.012/printnightmare/printnightmare.yml
+++ b/datasets/T1547.012/printnightmare/printnightmare.yml
@@ -1,0 +1,20 @@
+author: Michael Haag, Teoderick Contreras, Mauricio Velazco
+date: '2021-07-01'
+description: "Automated generation of attack data by exploiting CVE-2021-1675"
+environment: attack_range
+technique:
+- T1547.012
+dataset:
+- https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1547.012/printnightmware/windows-sysmon.log
+- https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1547.012/printnightmware/windows-security.log
+- https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1547.012/printnightmware/windows-system.log
+- https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1547.012/printnightmware/windows-printservice_operational.log
+- https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1547.012/printnightmware/windows-printservice_admin.log
+references:
+- https://attack.mitre.org/techniques/T1547/012/
+sourcetypes:
+- WinEventLog:Security
+- XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+- WinEventLog:System
+- WinEventLog:Microsoft-Windows-PrintService/Admin
+- WinEventLog:Microsoft-Windows-PrintService/Operational

--- a/datasets/T1547.012/printnightmare/windows-printservice_admin.log
+++ b/datasets/T1547.012/printnightmare/windows-printservice_admin.log
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:494d2ecc8b6ef3387088f6eadd1e25e6d03df159bf461ce314cc7f24245e71a6
+size 1008

--- a/datasets/T1547.012/printnightmare/windows-printservice_operational.log
+++ b/datasets/T1547.012/printnightmare/windows-printservice_operational.log
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b12a10215b2034ab1bd7e5d0d8ec1a15325fcec531cadab8d4d88f89b02462b7
+size 3693

--- a/datasets/T1547.012/printnightmare/windows-security.log
+++ b/datasets/T1547.012/printnightmare/windows-security.log
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6cc8a4db4d6bb55b4c00cba1ac4ce6f6b3f076e44f235537cf0dae30c76f6626
+size 293477924

--- a/datasets/T1547.012/printnightmare/windows-sysmon.log
+++ b/datasets/T1547.012/printnightmare/windows-sysmon.log
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e71f4c59caa60932c40fe56e8f1ea51c13baf113709775044ce5828a35ebd6f
+size 36652574

--- a/datasets/T1547.012/printnightmare/windows-system.log
+++ b/datasets/T1547.012/printnightmare/windows-system.log
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c6a6cc744c4bd5abaa53c1df360e30311e98b52be313a21617cf86e2de4bfd4
+size 6203


### PR DESCRIPTION
Adding attack_data gathered from the succesfull exploitation of CVE-2021-1675

- WinEventLog:Security
- XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
- WinEventLog:System
- WinEventLog:Microsoft-Windows-PrintService/Admin
- WinEventLog:Microsoft-Windows-PrintService/Operational
