### PR TITLE
Adding carbonblack datasets under atomic_red_team

### DIFF
--- a/datasets/attack_techniques/T1059.001/atomic_red_team/atomic_red_team.yml
+++ b/datasets/attack_techniques/T1059.001/atomic_red_team/atomic_red_team.yml
@@ -8,9 +8,11 @@ dataset:
 - https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1059.001/atomic_red_team/windows-powershell.log
 - https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1059.001/atomic_red_team/windows-sysmon.log
 - https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1059.001/atomic_red_team/windows-security.log
+- https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1059.001/atomic_red_team/carbon_black_events.log
 sourcetypes:
 - XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
 - WinEventLog:Microsoft-Windows-PowerShell/Operational
 - WinEventLog:Security
+- bit9:carbonblack:json
 references:
 - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1059.001/T1059.001.md

--- a/datasets/attack_techniques/T1059.001/atomic_red_team/carbon_black_events.log
+++ b/datasets/attack_techniques/T1059.001/atomic_red_team/carbon_black_events.log
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bec43f361e1896483f7363c82b01481e041e3f4bcbce27a03c41d8fb10749d42
+size 1954147

--- a/datasets/attack_techniques/T1105/atomic_red_team/atomic_red_team.yml
+++ b/datasets/attack_techniques/T1105/atomic_red_team/atomic_red_team.yml
@@ -10,9 +10,11 @@ dataset:
 - https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1105/atomic_red_team/windows-sysmon_curl.log
 - https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1105/atomic_red_team/windows-sysmon_curl_upload.log
 - https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1105/atomic_red_team/linux-sysmon_curlwget.log
+- https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1105/atomic_red_team/carbon_black_events.log
 sourcetypes:
 - XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
 - WinEventLog:Security
 - sysmon_linux
+- bit9:carbonblack:json
 references:
 - https://attack.mitre.org/techniques/T1105

--- a/datasets/attack_techniques/T1105/atomic_red_team/carbon_black_events.log
+++ b/datasets/attack_techniques/T1105/atomic_red_team/carbon_black_events.log
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3900a548587db2b98743492ac61c4f580989798e1c49af93e4b3e8cb5acd4f95
+size 1478202

--- a/datasets/attack_techniques/T1197/atomic_red_team/atomic_red_team.yml
+++ b/datasets/attack_techniques/T1197/atomic_red_team/atomic_red_team.yml
@@ -7,10 +7,12 @@ dataset:
 - https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1197/atomic_red_team/windows-security.log
 - https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1197/atomic_red_team/windows-sysmon.log
 - https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1197/atomic_red_team/windows-powershell.log
+- https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1197/atomic_red_team/carbon_black_events.log
 sourcetypes:
 - XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
 - WinEventLog:Microsoft-Windows-PowerShell/Operational
 - WinEventLog:Security
+- bit9:carbonblack:json
 references:
 - https://attack.mitre.org/techniques/T1197
 - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1197/T1197.md

--- a/datasets/attack_techniques/T1197/atomic_red_team/carbon_black_events.log
+++ b/datasets/attack_techniques/T1197/atomic_red_team/carbon_black_events.log
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3f28a3535a5edd3d910ab61953bd13ac09727da5413d02f53049b424aa198b92
+size 3289218


### PR DESCRIPTION
Created log files with carbonblack data generated using [Invoke Atomic Red Team](https://github.com/redcanaryco/invoke-atomicredteam/wiki/Execute-Atomic-Tests-(Local)).