### PR TITLE
Randomly named executable

### DIFF
--- a/datasets/attack_techniques/T1059/suspiciously_named_executables/suspiciously_named_executables.yaml
+++ b/datasets/attack_techniques/T1059/suspiciously_named_executables/suspiciously_named_executables.yaml
@@ -1,0 +1,11 @@
+author: Michael Hart
+id: 8179ffc0-7628-4c7b-a137-f17184efb4ed
+date: '2022-02-15'
+description: A sample log where an adversary compiles and runs an executable with a randomly generated name under the Windows folder, ostensibly to avoid detection.
+environment: attack_range
+dataset:
+- https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1059/suspiciously_named_executables/windows-sysmon.log
+sourcetypes:
+- XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
+references:
+- https://attack.mitre.org/techniques/T1059/

--- a/datasets/attack_techniques/T1059/suspiciously_named_executables/windows-sysmon.log
+++ b/datasets/attack_techniques/T1059/suspiciously_named_executables/windows-sysmon.log
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d22f7f0a6b0a25598928070de1e8901d7f1f140d975787f912286448ad8bcff
+size 1772


### PR DESCRIPTION
Example of an adversary running a randomly named executable in the C:\Windows folder, ostensibly to avoid detection