### PR TITLE
skip pathlib if python 3.4 or newer, its built in

### DIFF
--- a/bin/requirements.txt
+++ b/bin/requirements.txt
@@ -1,7 +1,7 @@
 certifi==2021.5.30
 chardet==4.0.0
 idna==2.10
-pathlib==1.0.1
+pathlib==1.0.1; python_version < '3.4'
 PyYAML==5.4.1
 requests==2.25.1
 splunk-sdk==1.6.18


### PR DESCRIPTION
``pip install -r bin/requirements.txt``  failing for me with python 3.7 ... turns out pathlib is already there. Adding a conditional pip install if using older version

References:
https://pypi.org/project/pathlib/
https://stackoverflow.com/questions/19559247/requirements-txt-depending-on-python-version

Note: I'd appreciate a second set of eyes/testing on this. I tested with my 3.7 and pip successfully skipped pathlib (worked) but I'm no pip expert (just found solution on StackOverflow).