### PR TITLE
specify running commands on actual Splunk server

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ A Repository of curated datasets from various attacks to:
 * [Replay](#replay-datasets) into streaming pipelines for validating your detections in your production SIEM
 
 # Installation
+Notes:
+* These steps are inteded to be ran on your actual Splunk host/server (not remotely)
+
 GitHub LFS is used in this project. For Mac users git-lfs can be derived with homebrew (for another OS click [here](https://github.com/git-lfs/git-lfs/wiki/Installation)):
 
 ````


### PR DESCRIPTION
I got tripped up and digging through code why it was failing. I was running this on my laptop and pointing it to an EC2 Splunk server. Figured out I believe these commands are supposed to be ran on the actual Splunk server .. so I ssh'd in and it worked.

This is my first time so if this is incorrect please don't merge, but hopefully helping someone else who comes behind and may try and populated data into a remote Splunk server (which didn't work for me)