### PR TITLE
Add Xml dataset for T1021.002 executable_file_written_in_administrati…

### DIFF
--- a/datasets/attack_techniques/T1021.002/atomic_red_team/windows-security-xml.log
+++ b/datasets/attack_techniques/T1021.002/atomic_red_team/windows-security-xml.log
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2ea2736ed21b1c7a9487fe7357535e5a436cea135bf955f21286fa51279caac3
+size 72587


### PR DESCRIPTION
Add an XML-formatted Windows Security Event dataset for T1021.002 simulated via Atomic Red Team.

NOTE: The following field names are different in xml vs multiline events:

- Relative_Target_Name -> RelativeTargetName
- Object_Type -> ObjectType
- Share_Name -> ShareName
- Access_Mask -> AccessMask