### PR TITLE
Add Xml dataset for T1021.002 executable_file_written_in_administrative_smb_share

### DIFF
--- a/datasets/attack_techniques/T1021.002/atomic_red_team/atomic_red_team.yml
+++ b/datasets/attack_techniques/T1021.002/atomic_red_team/atomic_red_team.yml
@@ -9,6 +9,7 @@ environment: attack_range
 dataset:
 - https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1021.002/atomic_red_team/windows-powershell.log
 - https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1021.002/atomic_red_team/windows-security.log
+- https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1021.002/atomic_red_team/windows-security-xml.log
 - https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1021.002/atomic_red_team/windows-sysmon.log
 - https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1021.002/atomic_red_team/windows-system.log
 sourcetypes:

--- a/datasets/attack_techniques/T1021.002/atomic_red_team/windows-security-xml.log
+++ b/datasets/attack_techniques/T1021.002/atomic_red_team/windows-security-xml.log
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2ea2736ed21b1c7a9487fe7357535e5a436cea135bf955f21286fa51279caac3
+size 72587

--- a/datasets/attack_techniques/T1021.002/atomic_red_team/windows-security-xml.log
+++ b/datasets/attack_techniques/T1021.002/atomic_red_team/windows-security-xml.log
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2ea2736ed21b1c7a9487fe7357535e5a436cea135bf955f21286fa51279caac3
-size 72587
+oid sha256:0b840eb0315fcbfd330af2dcd30bf616c67c816ba8a7d12d23135c24f28b1014
+size 72912


### PR DESCRIPTION
Add an XML-formatted Windows Security Event dataset for T1021.002 simulated via Atomic Red Team.

NOTE: The following field names are different in xml vs multiline events:

Relative_Target_Name -> RelativeTargetName
Object_Type -> ObjectType
Share_Name -> ShareName
Access_Mask -> AccessMask