### PR TITLE
Update for T1649 update

### DIFF
--- a/datasets/attack_techniques/T1649/certify_abuse/certify_esc1_abuse_sysmon.log
+++ b/datasets/attack_techniques/T1649/certify_abuse/certify_esc1_abuse_sysmon.log
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1b7b53fd066d8652eb15ac3d7beaffb3e771fb1edbfebba17055c9d646a40fed
-size 31520
+oid sha256:c7d23da3879695197d68564bc63a11b5b68d8c2570f41445d0b67a6ab29f90a3
+size 31531


### PR DESCRIPTION
Update to allow failed detection "Detect Certify File Modification" from https://github.com/splunk/security_content/pull/2777 to pass.