### PR TITLE
hollow out github runner to increase free space

### DIFF
--- a/.github/workflows/mirror_data_archive.yml
+++ b/.github/workflows/mirror_data_archive.yml
@@ -30,7 +30,7 @@ jobs:
         android: true
         dotnet: true
         haskell: true
-        large-packages: true
+        large-packages: false
         docker-images: true
         swap-storage: true
 


### PR DESCRIPTION
run on all branches, but do not s3 push.
use this for testing, for now. when 
we have verified it works, we will
update it to actually push again
and only run on master.

This fixes an issue where LFS checkout runs out of space.