### PR TITLE
Add attack_data for 3 Entra ID identity attack detections

### DIFF
--- a/datasets/attack_techniques/T1098.001/azure_ad_federated_identity_credential/azure-audit.log
+++ b/datasets/attack_techniques/T1098.001/azure_ad_federated_identity_credential/azure-audit.log
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68a71da7b6ee2370fd29439c2590620061973f11f2938261b98e489017653425
+size 2998

--- a/datasets/attack_techniques/T1098.001/azure_ad_federated_identity_credential/azure_ad_federated_identity_credential.yml
+++ b/datasets/attack_techniques/T1098.001/azure_ad_federated_identity_credential/azure_ad_federated_identity_credential.yml
@@ -1,0 +1,18 @@
+author: descambiado
+id: e3a7f1c2-9b4d-4e6a-8c1f-2d5a9b7e4c31
+date: '2026-06-10'
+description: Added a federated identity credential to an Entra ID service principal,
+  pointing the trust to an external GitHub Actions OIDC issuer/repo not controlled
+  by the tenant. Includes one benign Update service principal event (DisplayName
+  change) with no FederatedIdentityCredentials property, to validate filter specificity.
+  Tenant specific details have been replaced in the dataset including tenant id,
+  user names, ips, etc.
+environment: attack_range
+directory: azure_ad_federated_identity_credential
+mitre_technique:
+- T1098.001
+datasets:
+- name: azure-audit
+  path: /datasets/attack_techniques/T1098.001/azure_ad_federated_identity_credential/azure-audit.log
+  sourcetype: azure:monitor:aad
+  source: azure

--- a/datasets/attack_techniques/T1098/azure_ad_guest_user_type_changed_to_member/azure-audit.log
+++ b/datasets/attack_techniques/T1098/azure_ad_guest_user_type_changed_to_member/azure-audit.log
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a0e255c18f218b5ea3cd21393d0240c50c2e7662738055f107aa56968b3f5054
+size 2872

--- a/datasets/attack_techniques/T1098/azure_ad_guest_user_type_changed_to_member/azure_ad_guest_user_type_changed_to_member.yml
+++ b/datasets/attack_techniques/T1098/azure_ad_guest_user_type_changed_to_member/azure_ad_guest_user_type_changed_to_member.yml
@@ -1,0 +1,17 @@
+author: descambiado
+id: 4b8d2f6a-1c9e-4a3b-9d7f-6e2a4c8b1f95
+date: '2026-06-11'
+description: Changed the UserType property of an Entra ID guest account from Guest
+  to Member, removing the tenant-resource restrictions guest accounts normally carry.
+  Includes one benign Update user event (MobilePhone change) with no UserType property,
+  to validate filter specificity. Tenant specific details have been replaced in
+  the dataset including tenant id, user names, ips, etc.
+environment: attack_range
+directory: azure_ad_guest_user_type_changed_to_member
+mitre_technique:
+- T1098
+datasets:
+- name: azure-audit
+  path: /datasets/attack_techniques/T1098/azure_ad_guest_user_type_changed_to_member/azure-audit.log
+  sourcetype: azure:monitor:aad
+  source: azure

--- a/datasets/attack_techniques/T1556.006/azure_ad_temporary_access_pass/azure-audit.log
+++ b/datasets/attack_techniques/T1556.006/azure_ad_temporary_access_pass/azure-audit.log
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:95c51d3d30174a423c2e9522af278d565cbf882f1dc0b0cbf7e5e7a5aec4593d
+size 1394

--- a/datasets/attack_techniques/T1556.006/azure_ad_temporary_access_pass/azure_ad_temporary_access_pass.yml
+++ b/datasets/attack_techniques/T1556.006/azure_ad_temporary_access_pass/azure_ad_temporary_access_pass.yml
@@ -1,0 +1,17 @@
+author: descambiado
+id: 7f1a9c3e-5b2d-4f8a-b6e1-3c9d5a7f2b48
+date: '2026-06-12'
+description: Created a Temporary Access Pass for a Global Administrator account
+  outside of business hours, granting an MFA/FIDO2-bypassing authentication path
+  into the account. Tenant specific details have been replaced in the dataset including
+  tenant id, user names, ips, etc.
+environment: attack_range
+directory: azure_ad_temporary_access_pass
+mitre_technique:
+- T1556.006
+- T1078.004
+datasets:
+- name: azure-audit
+  path: /datasets/attack_techniques/T1556.006/azure_ad_temporary_access_pass/azure-audit.log
+  sourcetype: azure:monitor:aad
+  source: azure


### PR DESCRIPTION
## Summary
Test data requested by @nasbench on splunk/security_content#4091 for the 3 Entra ID identity attack detections:

- `azure_ad_federated_identity_credential_added_to_service_principal.yml` (T1098.001) — federated identity credential added to a service principal, pointing to an external GitHub Actions OIDC issuer
- `azure_ad_guest_user_type_changed_to_member.yml` (T1098) — guest account UserType changed to Member
- `azure_ad_temporary_access_pass_created.yml` (T1556.006, T1078.004) — Temporary Access Pass created for a Global Administrator account

Each dataset includes one true-positive event plus one benign noise event (unrelated property change on the same operation) to validate filter specificity. Tenant IDs, usernames, and IPs are synthetic/anonymized, following the existing `azure_ad_enable_and_reset` dataset format as a reference.

## Related
- splunk/security_content#4091

## Test plan
- [ ] Confirm `azure-audit.log` / `.yml` pairs match the existing dataset schema for `azure:monitor:aad` sourcetype
- [ ] Confirm each true-positive event fires the corresponding detection in security_content#4091