### PR TITLE
Fix snaattack misspelling

### DIFF
--- a/datasets/attack_techniques/T1001/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1001/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1001/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1001/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1003.001/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1003.001/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1003.001/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1003.001/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1003.002/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1003.002/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-PowerShell/Operational
-    path: /datasets/attack_techniques/T1003.002/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1003.002/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1003.003/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1003.003/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1003.003/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1003.003/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1003.004/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1003.004/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1003.004/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1003.004/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1003.005/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1003.005/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1003.005/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1003.005/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1003.006/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1003.006/snapattack/snapattack.yml
@@ -10,4 +10,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1003.006/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1003.006/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1003/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1003/snapattack/snapattack.yml
@@ -10,4 +10,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1003/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1003/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1006/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1006/snapattack/snapattack.yml
@@ -10,4 +10,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1006/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1006/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1011/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1011/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1011/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1011/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1012/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1012/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1012/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1012/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1016.001/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1016.001/snapattack/snapattack.yml
@@ -10,4 +10,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1016.001/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1016.001/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1020/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1020/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1020/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1020/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1021.002/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1021.002/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1021.002/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1021.002/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1021.004/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1021.004/snapattack/snapattack.yml
@@ -10,7 +10,7 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1021.004/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1021.004/snapattack/snapattack.log
 -   name: snapattack_linux
     sourcetype: sysmon:linux
     source: Syslog:Linux-Sysmon/Operational

--- a/datasets/attack_techniques/T1021/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1021/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1021/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1021/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1022/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1022/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1022/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1022/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1027.009/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1027.009/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1027.009/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1027.009/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1027.010/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1027.010/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1027.010/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1027.010/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1027/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1027/snapattack/snapattack.yml
@@ -10,4 +10,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1027/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1027/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1030/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1030/snapattack/snapattack.yml
@@ -10,4 +10,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-PowerShell/Operational
-    path: /datasets/attack_techniques/T1030/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1030/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1033/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1033/snapattack/snapattack.yml
@@ -10,7 +10,7 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1033/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1033/snapattack/snapattack.log
 -   name: snapattack_linux
     sourcetype: sysmon:linux
     source: Syslog:Linux-Sysmon/Operational

--- a/datasets/attack_techniques/T1036.005/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1036.005/snapattack/snapattack.yml
@@ -10,4 +10,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1036.005/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1036.005/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1036/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1036/snapattack/snapattack.yml
@@ -11,7 +11,7 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1036/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1036/snapattack/snapattack.log
 -   name: snapattack_linux
     sourcetype: sysmon:linux
     source: Syslog:Linux-Sysmon/Operational

--- a/datasets/attack_techniques/T1037.005/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1037.005/snapattack/snapattack.yml
@@ -11,7 +11,7 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-PowerShell/Operational
-    path: /datasets/attack_techniques/T1037.005/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1037.005/snapattack/snapattack.log
 -   name: snapattack_linux
     sourcetype: sysmon:linux
     source: Syslog:Linux-Sysmon/Operational

--- a/datasets/attack_techniques/T1047/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1047/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1047/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1047/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1053/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1053/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1053/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1053/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1055/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1055/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1055/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1055/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1057/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1057/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-PowerShell/Operational
-    path: /datasets/attack_techniques/T1057/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1057/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1059.001/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1059.001/snapattack/snapattack.yml
@@ -10,4 +10,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-PowerShell/Operational
-    path: /datasets/attack_techniques/T1059.001/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1059.001/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1059.003/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1059.003/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1059.003/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1059.003/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1059.005/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1059.005/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1059.005/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1059.005/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1059.006/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1059.006/snapattack/snapattack.yml
@@ -10,4 +10,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1059.006/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1059.006/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1059.007/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1059.007/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1059.007/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1059.007/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1059/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1059/snapattack/snapattack.yml
@@ -11,7 +11,7 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1059/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1059/snapattack/snapattack.log
 -   name: snapattack_linux
     sourcetype: sysmon:linux
     source: Syslog:Linux-Sysmon/Operational

--- a/datasets/attack_techniques/T1068/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1068/snapattack/snapattack.yml
@@ -11,7 +11,7 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1068/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1068/snapattack/snapattack.log
 -   name: snapattack_linux
     sourcetype: sysmon:linux
     source: Syslog:Linux-Sysmon/Operational

--- a/datasets/attack_techniques/T1069/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1069/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1069/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1069/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1071.001/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1071.001/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1071.001/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1071.001/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1071.004/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1071.004/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1071.004/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1071.004/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1074/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1074/snapattack/snapattack.yml
@@ -10,4 +10,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1074/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1074/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1078.001/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1078.001/snapattack/snapattack.yml
@@ -10,4 +10,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1078.001/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1078.001/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1078.003/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1078.003/snapattack/snapattack.yml
@@ -10,4 +10,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1078.003/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1078.003/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1078/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1078/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-PowerShell/Operational
-    path: /datasets/attack_techniques/T1078/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1078/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1082/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1082/snapattack/snapattack.yml
@@ -11,7 +11,7 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-PowerShell/Operational
-    path: /datasets/attack_techniques/T1082/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1082/snapattack/snapattack.log
 -   name: snapattack_linux
     sourcetype: sysmon:linux
     source: Syslog:Linux-Sysmon/Operational

--- a/datasets/attack_techniques/T1087.002/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1087.002/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1087.002/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1087.002/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1090/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1090/snapattack/snapattack.yml
@@ -10,4 +10,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1090/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1090/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1112/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1112/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1112/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1112/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1119/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1119/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1119/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1119/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1128/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1128/snapattack/snapattack.yml
@@ -10,4 +10,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1128/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1128/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1129/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1129/snapattack/snapattack.yml
@@ -10,7 +10,7 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1129/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1129/snapattack/snapattack.log
 -   name: snapattack_linux
     sourcetype: sysmon:linux
     source: Syslog:Linux-Sysmon/Operational

--- a/datasets/attack_techniques/T1133/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1133/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1133/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1133/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1136.002/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1136.002/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1136.002/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1136.002/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1136/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1136/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1136/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1136/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1137.006/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1137.006/snapattack/snapattack.yml
@@ -10,4 +10,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1137.006/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1137.006/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1140/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1140/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-PowerShell/Operational
-    path: /datasets/attack_techniques/T1140/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1140/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1187/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1187/snapattack/snapattack.yml
@@ -10,4 +10,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1187/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1187/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1190/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1190/snapattack/snapattack.yml
@@ -11,7 +11,7 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1190/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1190/snapattack/snapattack.log
 -   name: snapattack_linux
     sourcetype: sysmon:linux
     source: Syslog:Linux-Sysmon/Operational

--- a/datasets/attack_techniques/T1203/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1203/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1203/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1203/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1204.002/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1204.002/snapattack/snapattack.yml
@@ -11,7 +11,7 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1204.002/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1204.002/snapattack/snapattack.log
 -   name: snapattack_linux
     sourcetype: sysmon:linux
     source: Syslog:Linux-Sysmon/Operational

--- a/datasets/attack_techniques/T1204/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1204/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1204/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1204/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1207/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1207/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1207/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1207/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1210/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1210/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1210/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1210/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1217/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1217/snapattack/snapattack.yml
@@ -10,4 +10,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1217/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1217/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1218.007/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1218.007/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1218.007/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1218.007/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1218.010/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1218.010/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1218.010/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1218.010/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1218.011/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1218.011/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1218.011/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1218.011/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1218.014/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1218.014/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1218.014/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1218.014/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1218/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1218/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1218/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1218/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1219/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1219/snapattack/snapattack.yml
@@ -10,4 +10,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-PowerShell/Operational
-    path: /datasets/attack_techniques/T1219/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1219/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1222/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1222/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1222/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1222/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1482/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1482/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-PowerShell/Operational
-    path: /datasets/attack_techniques/T1482/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1482/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1484.001/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1484.001/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1484.001/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1484.001/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1485/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1485/snapattack/snapattack.yml
@@ -10,4 +10,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1485/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1485/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1490/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1490/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1490/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1490/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1491.001/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1491.001/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1491.001/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1491.001/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1491/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1491/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1491/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1491/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1497/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1497/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1497/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1497/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1505.003/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1505.003/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1505.003/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1505.003/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1505/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1505/snapattack/snapattack.yml
@@ -11,7 +11,7 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1505/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1505/snapattack/snapattack.log
 -   name: snapattack_linux
     sourcetype: sysmon:linux
     source: Syslog:Linux-Sysmon/Operational

--- a/datasets/attack_techniques/T1518/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1518/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-PowerShell/Operational
-    path: /datasets/attack_techniques/T1518/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1518/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1526/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1526/snapattack/snapattack.yml
@@ -10,4 +10,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1526/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1526/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1542.001/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1542.001/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1542.001/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1542.001/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1542.003/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1542.003/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1542.003/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1542.003/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1543.003/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1543.003/snapattack/snapattack.yml
@@ -10,4 +10,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1543.003/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1543.003/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1546.008/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1546.008/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1546.008/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1546.008/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1546.009/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1546.009/snapattack/snapattack.yml
@@ -10,7 +10,7 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1546.009/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1546.009/snapattack/snapattack.log
 -   name: registry_entry
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational

--- a/datasets/attack_techniques/T1547.001/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1547.001/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1547.001/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1547.001/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1547.009/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1547.009/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1547.009/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1547.009/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1547.012/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1547.012/snapattack/snapattack.yml
@@ -10,4 +10,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1547.012/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1547.012/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1552/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1552/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-PowerShell/Operational
-    path: /datasets/attack_techniques/T1552/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1552/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1553.002/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1553.002/snapattack/snapattack.yml
@@ -10,4 +10,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1553.002/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1553.002/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1555.003/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1555.003/snapattack/snapattack.yml
@@ -10,4 +10,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1555.003/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1555.003/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1556.002/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1556.002/snapattack/snapattack.yml
@@ -10,4 +10,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1556.002/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1556.002/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1560.002/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1560.002/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1560.002/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1560.002/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1562.001/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1562.001/snapattack/snapattack.yml
@@ -10,4 +10,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1562.001/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1562.001/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1562.004/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1562.004/snapattack/snapattack.yml
@@ -10,4 +10,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1562.004/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1562.004/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1562.009/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1562.009/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1562.009/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1562.009/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1562/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1562/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-PowerShell/Operational
-    path: /datasets/attack_techniques/T1562/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1562/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1564/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1564/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1564/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1564/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1566/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1566/snapattack/snapattack.yml
@@ -10,4 +10,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1566/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1566/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1567.002/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1567.002/snapattack/snapattack.yml
@@ -10,4 +10,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1567.002/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1567.002/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1567/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1567/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1567/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1567/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1569/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1569/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1569/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1569/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1570/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1570/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1570/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1570/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1572/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1572/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1572/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1572/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1574.002/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1574.002/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1574.002/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1574.002/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1574.008/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1574.008/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1574.008/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1574.008/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1574/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1574/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1574/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1574/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1589.001/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1589.001/snapattack/snapattack.yml
@@ -10,4 +10,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1589.001/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1589.001/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1590/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1590/snapattack/snapattack.yml
@@ -10,4 +10,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-PowerShell/Operational
-    path: /datasets/attack_techniques/T1590/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1590/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1595.001/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1595.001/snapattack/snapattack.yml
@@ -11,4 +11,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1595.001/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1595.001/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1595/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1595/snapattack/snapattack.yml
@@ -10,4 +10,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Security
-    path: /datasets/attack_techniques/T1595/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1595/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1608.001/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1608.001/snapattack/snapattack.yml
@@ -10,4 +10,4 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1608.001/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1608.001/snapattack/snapattack.log

--- a/datasets/attack_techniques/T1608/snapattack/snapattack.yml
+++ b/datasets/attack_techniques/T1608/snapattack/snapattack.yml
@@ -10,7 +10,7 @@ datasets:
 -   name: snapattack
     sourcetype: XmlWinEventLog
     source: XmlWinEventLog:Microsoft-Windows-Sysmon/Operational
-    path: /datasets/attack_techniques/T1608/snapattack/snaattack.log
+    path: /datasets/attack_techniques/T1608/snapattack/snapattack.log
 -   name: snapattack_linux
     sourcetype: sysmon:linux
     source: Syslog:Linux-Sysmon/Operational


### PR DESCRIPTION
The yml manifest files have 114 instances of "snapattack" misspelled as "snaattack". This PR fixes those misspellings, ensuring that each changed file actually maps to a real "snapattack.log".

A script to verify the problem and make the edit can be found at [this gist](https://gist.github.com/lcorcodilos/93d3757313742c9765569e01f2478016). I used this with the `--write` flag to create the changes in the PR.