### PR TITLE
Updating Osascript Telemetry with Correct Set of Events

### DIFF
--- a/datasets/attack_techniques/T1059.002/osascript/osascript_prompts_user.log
+++ b/datasets/attack_techniques/T1059.002/osascript/osascript_prompts_user.log
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8d9a4664b4659024da715b6686e50c86cfd95ca6f6616f1652ade5134cb4aaa2
-size 2853
+oid sha256:d2e518e745c7ec64e184dd1826da8c256a035d322352cf517f9f333a5a0b07f0
+size 7092


### PR DESCRIPTION
Updating "MacOS Utility Osascript Prompting for User Interaction" telemetry with correct set of events.

Previous set of telemetry did not contain raw osquery events.