### PR TITLE
Add macOS browser spawned script external network connection dataset

### DIFF
--- a/datasets/attack_techniques/T1059/macos_browser_spawned_script_external_network_connection/nvm_flowdata.log
+++ b/datasets/attack_techniques/T1059/macos_browser_spawned_script_external_network_connection/nvm_flowdata.log
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4d990849f651dea10df286d51673b1d09dc536b03a82df3f9e113b4e8c9ce13c
+size 1069

--- a/datasets/attack_techniques/T1059/macos_browser_spawned_script_external_network_connection/nvm_flowdata.yml
+++ b/datasets/attack_techniques/T1059/macos_browser_spawned_script_external_network_connection/nvm_flowdata.yml
@@ -1,0 +1,13 @@
+author: Maria Jose Erquiaga
+id: 436d5044-ae22-475d-9e19-dfc8a2f4e94f
+date: '2026-09-02'
+description: Generated datasets for Cisco Network Visibility Module Flow Data EventType.
+environment: custom
+directory: macos_browser_spawned_script_external_network_connection
+mitre_technique:
+    - T1059
+datasets:
+    - name: nvm_flowdata
+      sourcetype: cisco:nvm:flowdata:v2
+      source: not_applicable
+      path: /datasets/attack_techniques/T1059/macos_browser_spawned_script_external_network_connection/nvm_flowdata.log


### PR DESCRIPTION
## Summary

Adds attack data for a macOS browser spawning a script that establishes an external network connection.

## Data

- Raw process telemetry exported from Splunk
- Dataset metadata describing the experiment
- Log data stored using Git LFS

## Validation

- Dataset YAML syntax validated
- Raw telemetry reviewed against the detection behavior
- Git LFS attributes and pointer verified